### PR TITLE
feat: particles bg

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,7 @@ body {
   padding: 0;
   margin: 0;
 
-  background-color: #bac9ce;
+  background-color: #02020f;
 }
 
 .centered-div {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import "./App.css";
-import { Ambient } from "./components/Image";
+import { Particles } from "./components/Background";
 
 const App = () => {
   return (
     <main>
       <div className="centered-div">
-        <Ambient />
+        <Particles />
       </div>
     </main>
   );

--- a/src/components/Background/Particles/Particles.css
+++ b/src/components/Background/Particles/Particles.css
@@ -1,0 +1,11 @@
+.canvas-bg {
+  position: absolute;
+
+  top: 0%;
+  left: 0%;
+
+  width: 100%;
+  height: 100%;
+
+  z-index: -10;
+}

--- a/src/components/Background/Particles/Particles.tsx
+++ b/src/components/Background/Particles/Particles.tsx
@@ -1,7 +1,29 @@
+import { useEffect, useRef } from "react";
 import "./Particles.css";
+import { useMousePosition } from "../../../hooks";
+import { animateParticles, createParticles, createWaves } from "./utils";
 
 const Particles = () => {
-  return <div></div>;
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { mouseRef } = useMousePosition();
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    canvas.width = 1728;
+    canvas.height = 897;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const particles = createParticles();
+    const waves = createWaves();
+
+    animateParticles(canvas, particles, waves, mouseRef);
+  }, []);
+
+  return <canvas className="canvas-bg" ref={canvasRef}></canvas>;
 };
 
 export default Particles;

--- a/src/components/Background/Particles/Particles.tsx
+++ b/src/components/Background/Particles/Particles.tsx
@@ -1,0 +1,7 @@
+import "./Particles.css";
+
+const Particles = () => {
+  return <div></div>;
+};
+
+export default Particles;

--- a/src/components/Background/Particles/Particles.tsx
+++ b/src/components/Background/Particles/Particles.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import "./Particles.css";
 import { useMousePosition } from "../../../hooks";
 import { animateParticles, createParticles, createWaves } from "./utils";
+import { MOUSE_INITIAL_STATE } from "./const";
 
 const Particles = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -20,7 +21,7 @@ const Particles = () => {
     const particles = createParticles();
     const waves = createWaves();
 
-    animateParticles(canvas, particles, waves, mouseRef);
+    animateParticles(canvas, particles, waves, mouseRef, MOUSE_INITIAL_STATE);
   }, []);
 
   return <canvas className="canvas-bg" ref={canvasRef}></canvas>;

--- a/src/components/Background/Particles/const.ts
+++ b/src/components/Background/Particles/const.ts
@@ -1,0 +1,49 @@
+export const THEMES = {
+  PALETTE_1: ["#264653", "#2a9d8f", "#e9c46a", "#f4a261", "#e76f51"],
+  PALETTE_2: ["#f4f1de", "#e07a5f", "#3d405b", "#81b29a", "#f2cc8f"],
+  PALETTE_3: ["#fff"],
+  PALETTE_4: ["#FEFFD2", "#FFEEA9", "#FFBF78", "#FF7D29"],
+  PALETTE_5: ["#a67c00", "#bf9b30", "#ffbf00", "#ffcf40", "#ffdc73"],
+  PALETTE_6: ["#c4c4fd", "#ffec9c", "#6a71a5", "#35336b", "#091e36"],
+};
+
+export const MOUSE_MODES = {
+  REPULSION: "repulsion",
+  ATTRACTION: "attraction",
+  OFF: "off",
+};
+
+export const CONFIG = {
+  PARTICLES_AMOUNT: 100,
+  SPEED: 0.2,
+  SPEED_DELTA: 0.1,
+  ANGLE_DELTA: 0.05,
+  FLOAT_SPEED_DELTA: 0.3,
+  DISTANCE_ACCELERATOR: 0.01,
+  DISTANCE_SLOW: 0.005,
+  SPEED_CAP: 1.8,
+  CANVAS_WIDTH: 1728,
+  CANVAS_HEIGHT: 897,
+  DOT_SIZE: 2,
+  ARC_SIZE: 3,
+  INTERACTION_DISTANCE: 100,
+  PALETTE: THEMES.PALETTE_1,
+  MOUSE_MODE: MOUSE_MODES.OFF,
+  ENABLE_WAVES: true,
+};
+
+export const WAVES_CONFIG = {
+  COUNT: 1,
+  BASE_SPEED: 0.5,
+  SIZE: 50,
+  SPEED_DELTA: 0.4,
+  ANGLE_DELTA: 0.1,
+};
+
+export const MOUSE_INITIAL_STATE = {
+  x: -1 * CONFIG.INTERACTION_DISTANCE,
+  y: -1 * CONFIG.INTERACTION_DISTANCE,
+  prevX: -1 * CONFIG.INTERACTION_DISTANCE,
+  prevY: -1 * CONFIG.INTERACTION_DISTANCE,
+  angle: 0,
+};

--- a/src/components/Background/Particles/const.ts
+++ b/src/components/Background/Particles/const.ts
@@ -14,7 +14,7 @@ export const MOUSE_MODES = {
 };
 
 export const CONFIG = {
-  PARTICLES_AMOUNT: 100,
+  PARTICLES_AMOUNT: 300,
   SPEED: 0.2,
   SPEED_DELTA: 0.1,
   ANGLE_DELTA: 0.05,
@@ -24,7 +24,6 @@ export const CONFIG = {
   SPEED_CAP: 1.8,
   CANVAS_WIDTH: 1728,
   CANVAS_HEIGHT: 897,
-  DOT_SIZE: 2,
   ARC_SIZE: 3,
   INTERACTION_DISTANCE: 100,
   PALETTE: THEMES.PALETTE_1,
@@ -33,7 +32,7 @@ export const CONFIG = {
 };
 
 export const WAVES_CONFIG = {
-  COUNT: 1,
+  COUNT: 10,
   BASE_SPEED: 0.5,
   SIZE: 50,
   SPEED_DELTA: 0.4,

--- a/src/components/Background/Particles/index.ts
+++ b/src/components/Background/Particles/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Particles";

--- a/src/components/Background/Particles/types.ts
+++ b/src/components/Background/Particles/types.ts
@@ -1,0 +1,21 @@
+export type Entity = {
+  x: number;
+  y: number;
+  angle: number;
+  speed: number;
+};
+
+export type InteractableEntity = Pick<Entity, "x" | "y" | "angle">;
+
+export type ParticleEntity = Entity & {
+  maxFloatingSpeed: number;
+  color: string;
+};
+
+export type Mouse = {
+  x: number;
+  y: number;
+  prevX: number;
+  prevY: number;
+  angle: number;
+};

--- a/src/components/Background/index.ts
+++ b/src/components/Background/index.ts
@@ -1,0 +1,1 @@
+export { default as Particles } from "./Particles";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useMousePosition } from "./useMousePosition";

--- a/src/hooks/useMousePosition.ts
+++ b/src/hooks/useMousePosition.ts
@@ -1,0 +1,36 @@
+import { Ref, useCallback, useEffect, useRef } from "react";
+
+export type MousePosition = {
+  x: number;
+  y: number;
+};
+
+type UseMousePosition = {
+  mouseRef: Ref<MousePosition>;
+};
+
+const useMousePosition = (): UseMousePosition => {
+  const mouseRef = useRef<MousePosition>({
+    x: 0,
+    y: 0,
+  });
+
+  const onMouseMove = useCallback((e: MouseEvent) => {
+    mouseRef.current = {
+      x: e.clientX,
+      y: e.clientY,
+    };
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("mousemove", onMouseMove);
+
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+    };
+  }, []);
+
+  return { mouseRef };
+};
+
+export default useMousePosition;

--- a/src/hooks/useMousePosition.ts
+++ b/src/hooks/useMousePosition.ts
@@ -1,4 +1,4 @@
-import { Ref, useCallback, useEffect, useRef } from "react";
+import { RefObject, useCallback, useEffect, useRef } from "react";
 
 export type MousePosition = {
   x: number;
@@ -6,7 +6,7 @@ export type MousePosition = {
 };
 
 type UseMousePosition = {
-  mouseRef: Ref<MousePosition>;
+  mouseRef: RefObject<MousePosition>;
 };
 
 const useMousePosition = (): UseMousePosition => {


### PR DESCRIPTION
Add particles background

The main feature is waves that move particles around the canvas. Waves can be enabled and disabled. It uses a lot of performance since the current complexity is p * w (where p is the number of particles and w is the number of waves) per frame. But looks cool.

You can enable mouse interaction with particles by toggling values in CONFIG. Mouse interaction has three modes: OFF, ATTRACTION, and REPULSION. It's pretty self-explanatory what these modes do.